### PR TITLE
Update container python version.

### DIFF
--- a/cf_automate_zanshin_onboard_aws_organizations.yml
+++ b/cf_automate_zanshin_onboard_aws_organizations.yml
@@ -99,7 +99,7 @@ Resources:
               Value:
                 Ref: MemberAccountsRoleName
           Essential: true
-          Image: public.ecr.aws/bitnami/python:3.9
+          Image: public.ecr.aws/bitnami/python:3.12
           LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
Updates python version used in container to 3.12.

zanshincli dropped support for python 3.9 in the most recent releases.